### PR TITLE
Promote IOException in sendPacket()

### DIFF
--- a/bglib-protocol-1.0.3-43/src/main/java/org/thingml/bglib/BGAPITransport.java
+++ b/bglib-protocol-1.0.3-43/src/main/java/org/thingml/bglib/BGAPITransport.java
@@ -15,6 +15,7 @@
  */
 package org.thingml.bglib;
 
+import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -57,10 +58,11 @@ public class BGAPITransport implements Runnable {
     public void sendPacket(BGAPIPacket p) {
         try {
             out.write(p.getPacketBytes());
-            for(BGAPITransportListener l : listeners) l.packetSent(p);
         } catch (IOException ex) {
             Logger.getLogger(BGAPITransport.class.getName()).log(Level.SEVERE, null, ex);
+            throw new IOError(ex);
         }
+        for(BGAPITransportListener l : listeners) l.packetSent(p);
     }
     
     

--- a/bglib-protocol-1.1.0-55Beta/src/main/java/org/thingml/bglib/BGAPITransport.java
+++ b/bglib-protocol-1.1.0-55Beta/src/main/java/org/thingml/bglib/BGAPITransport.java
@@ -15,6 +15,7 @@
  */
 package org.thingml.bglib;
 
+import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -57,10 +58,11 @@ public class BGAPITransport implements Runnable {
     public void sendPacket(BGAPIPacket p) {
         try {
             out.write(p.getPacketBytes());
-            for(BGAPITransportListener l : listeners) l.packetSent(p);
         } catch (IOException ex) {
             Logger.getLogger(BGAPITransport.class.getName()).log(Level.SEVERE, null, ex);
+            throw new IOError(ex);
         }
+        for(BGAPITransportListener l : listeners) l.packetSent(p);
     }
     
     


### PR DESCRIPTION
When dongle is removed from computer, out.write() causes IOException to
be thrown, however sendPacket() catches it and doesn't give any feedback
for listeners or anybody else. That causes listeners to wait forever for
event that will never occur because message was not sent.

This patch promotes IOException as IOError to upper layers, so that
caller can handle it and react appropriately.
