### PR TITLE
Synchronize listeners

### DIFF
--- a/bglib-protocol-1.0.3-43/src/main/java/org/thingml/bglib/BGAPI.java
+++ b/bglib-protocol-1.0.3-43/src/main/java/org/thingml/bglib/BGAPI.java
@@ -15,7 +15,8 @@
  */
 package org.thingml.bglib;
 
-import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  *
@@ -38,8 +39,8 @@ public class BGAPI implements BGAPITransportListener {
         bgapi.stop();
     }
     
-    public ArrayList<BGAPIListener> listeners = new ArrayList<BGAPIListener>();
-     public void addListener(BGAPIListener l) {
+    public List<BGAPIListener> listeners = new CopyOnWriteArrayList<BGAPIListener>();
+    public void addListener(BGAPIListener l) {
         listeners.add(l);
     }
     public void removeListener(BGAPIListener l) {

--- a/bglib-protocol-1.1.0-55Beta/src/main/java/org/thingml/bglib/BGAPI.java
+++ b/bglib-protocol-1.1.0-55Beta/src/main/java/org/thingml/bglib/BGAPI.java
@@ -16,6 +16,7 @@
 package org.thingml.bglib;
 
 import java.util.ArrayList;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  *
@@ -30,8 +31,8 @@ public class BGAPI implements BGAPITransportListener {
         bgapi.addListener(this);
     }
     
-    public ArrayList<BGAPIListener> listeners = new ArrayList<BGAPIListener>();
-     public void addListener(BGAPIListener l) {
+    public List<BGAPIListener> listeners = new CopyOnWriteArrayList<BGAPIListener>();
+    public void addListener(BGAPIListener l) {
         listeners.add(l);
     }
     public void removeListener(BGAPIListener l) {


### PR DESCRIPTION
Java's synchronized blocks are reetrant, so it wasn't possible to
unsubscribe from handler. This patch uses CopyOnWriteArrayList that
makes it possible to remove listeners while iterating over a list.
